### PR TITLE
Fix exception on POSIX systems

### DIFF
--- a/bk7231tools/serial/__init__.py
+++ b/bk7231tools/serial/__init__.py
@@ -25,7 +25,9 @@ class BK7231Serial(BK7231CmdFlash):
             baudrate=link_baudrate,
             timeout=cmnd_timeout,
         )
-        self.serial.set_buffer_size(rx_size=8192)
+        if hasattr(self.serial, "set_buffer_size"):
+            # This method doesn't exist in pyserial POSIX implementation
+            self.serial.set_buffer_size(rx_size=8192)
         self.baudrate = baudrate
         self.link_timeout = link_timeout
         self.cmnd_timeout = cmnd_timeout


### PR DESCRIPTION
In `bk7231tools.serial.BK7231Serial.__init__()`, after initializing the `serial.Serial` object, calling its `set_buffer_size()` method results in the following exception.

```
AttributeError: 'Serial' object has no attribute 'set_buffer_size'
File "[...]/bk7231tools/serial/__init__.py", line 28, in __init__
```

That method is peculiar to the [Windows implementation][1], and doesn't exist in the POSIX (or java) implementations.

[1]: https://github.com/pyserial/pyserial/blob/master/serial/serialwin32.py#L418