### PR TITLE
Stage clearing DTR+RTS during hardware reset

### DIFF
--- a/bk7231tools/serial/protocol.py
+++ b/bk7231tools/serial/protocol.py
@@ -116,8 +116,9 @@ class BK7231Protocol:
         self.serial.rts = True
         self.serial.dtr = True
         sleep(0.1)
-        self.serial.rts = False
         self.serial.dtr = False
+        sleep(0.1)
+        self.serial.rts = False
 
     def drain(self):
         tm_prev = self.serial.timeout


### PR DESCRIPTION
Some burners (like [this one][1]) have odd coupling between DTR and RTS inputs, and EN/RST and GPIO0 outputs.  On these burners, clearing both DTR and RTS at once will not lower EN and GPIO0.  To clear EN and GPIO0, DTR must be low while RTS is high.

To achieve this, this patch clears DTR first, and after a short sleep, then clears RTS.

More details at https://github.com/kuba2k2/libretuya/issues/85.

[1]:  https://www.pcbway.com/project/shareproject/esp8266_burning_rack.html