### PR TITLE
Retry flash reading in case of errors

### DIFF
--- a/bk7231tools/serial/cmd_flash.py
+++ b/bk7231tools/serial/cmd_flash.py
@@ -62,7 +62,7 @@ class BK7231CmdFlash(BK7231CmdChip):
     }
 
     flash_id: bytes = None
-    retries : int = 20
+    retries: int = 20
 
     def flash_write_bytes(
         self,
@@ -132,8 +132,8 @@ class BK7231CmdFlash(BK7231CmdChip):
                     if crc_check:
                         self.check_crc(addr, response.data)
                     break
-                except ValueError as ve:
-                    self.warn(f"Reading failure ({str(ve)}), retrying (attempt {j})")
+                except ValueError as e:
+                    self.warn(f"Reading failure ({e}), retrying (attempt {j})")
             yield response.data
 
     def flash_read_reg8(self, cmd: int) -> int:

--- a/bk7231tools/serial/cmd_flash.py
+++ b/bk7231tools/serial/cmd_flash.py
@@ -124,11 +124,15 @@ class BK7231CmdFlash(BK7231CmdChip):
             addr = start + i * 4096
             progress = i / length * 100.0
             self.info(f"Reading 4k page at 0x{addr:06X} ({progress:.2f}%)")
-            command = BkFlashRead4KCmnd(addr)
-            response: BkFlashRead4KResp = self.command(command)
-            if crc_check:
-                self.check_crc(addr, response.data)
-            yield response.data
+            while True:
+                try:
+                    command = BkFlashRead4KCmnd(addr)
+                    response: BkFlashRead4KResp = self.command(command)
+                    if crc_check:
+                        self.check_crc(addr, response.data)
+                    break
+                except ValueError as ve:
+                    self.warn(f"Reading failure ({str(ve)}), retrying")
 
     def flash_read_reg8(self, cmd: int) -> int:
         command = BkFlashReg8ReadCmnd(cmd)


### PR DESCRIPTION
This PR adds a feature allowing the read to be automatically retried if failed.

Useful for serial connections with issues, although I suspect that the underlying serial code gives up too quickly if the requested bytes aren't in the buffer by a certain time period.