### PR TITLE
Update read/erase/write retry policy

### DIFF
--- a/bk7231tools/serial/protocol.py
+++ b/bk7231tools/serial/protocol.py
@@ -28,6 +28,7 @@ class ProtocolType(Enum):
         (0x0E, SHORT),  # CMD_Reboot
         (0x0F, SHORT),  # CMD_SetBaudRate
         (0x10, SHORT),  # CMD_CheckCRC
+        (0x11, SHORT),  # CMD_ReadBootVersion
         (0x70, SHORT),  # CMD_RESET
         (0xAA, SHORT),  # CMD_StayRom
         (0x06, LONG),  # CMD_FlashWrite


### PR DESCRIPTION
1. flash_read - throw an exception if maximum attempts reached
2. flash_erase_block - retry if cannot erase block
3. flash_write_4k - retry if cannot write. Set crc_check to True

Note:
NAS-AB02W6 - fails to update firmware without this even with external power supply.